### PR TITLE
Update dynamic.json

### DIFF
--- a/dynamic.json
+++ b/dynamic.json
@@ -5,7 +5,6 @@
 			"cost": 8,
 			"scaling_cost": 9,
 			"weight": 8,
-			"required_candidates": 1,
 			"minimum_required_age": 14
 		},
 
@@ -141,6 +140,7 @@
 
 		"Heretic Smuggler": {
 			"weight": 5,
+			"cost": 8
 			"minimum_required_age": 14
 		}
 	}


### PR DESCRIPTION
Lowered minimum round time for heavier antags, (45 minutes vs 90 minutes) and raised cost for cheap antags so that they aren't so easily spammed.