### PR TITLE
Disables DIRT

### DIFF
--- a/skyrat/skyrat_config.txt
+++ b/skyrat/skyrat_config.txt
@@ -91,7 +91,7 @@ PC_MOB_TEXT As a player controlled mob you are expected to play the role to the 
 #RUSSIAN_TEXT_FORMATION
 
 ## Toggles off SSDecay when uncommented, HIGHLY recommended for map test-merges, to avoid giving it a bad first impression.
-#SSDECAY_DISABLED
+SSDECAY_DISABLED
 
 ## Toggles off SSDecay nests when uncommented, HIGHLY recommended for map test-merges, to avoid giving it a bad first impression.
 ## If SSDECAY_DISABLED is uncommented, then it does not matter if this is commented out since this config requires SSDecay to be enabled first.


### PR DESCRIPTION
Dirty ass stations DISABLED

However, mice, bee, etc. spawners in maint stay
Mwahahaha
(I can also disable the mini-spawners though if you want)