### PR TITLE
Dynamic Cost Adjustments

### DIFF
--- a/dynamic.json
+++ b/dynamic.json
@@ -10,7 +10,7 @@
 			"minimum_required_age": 14
 		},
 
-		"Blood Brothers": {	
+		"Blood Brothers": {
 			"weight": 8,
 			"minimum_required_age": 14
 		},
@@ -150,7 +150,7 @@
 		"Blob Infection": {
 			"weight": 1,
 			"cost": 30,
-			"minimum_players:" 40,
+			"minimum_players": 40,
 			"minimum_required_age": 14,
 			"minimum_round_time": 27000,
 			"requirements": [


### PR DESCRIPTION
Increases the cost of rulesets that are either very disruptive, or very annoying and extremely difficult to kill on lowpop due to either robustness or ease of escaping.
Makes my top habibi Blobbers more likely, but only if there's 40 players!