### PR TITLE
Halves AI Required Playtime

### DIFF
--- a/jobconfig.toml
+++ b/jobconfig.toml
@@ -17,7 +17,7 @@
 ## Best of luck editing!
 
 [AI]
-"Playtime Requirements" = 2400
+"Playtime Requirements" = 1200
 "Required Account Age" = 30
 "Spawn Positions" = 1
 "Total Positions" = 1


### PR DESCRIPTION
This PR aims to halve the playtime required from 40 hours to 20 hours

### Why should this be added?

Because you don't need 40 hours as a borg to know how you play an AI. 