### PR TITLE
Disables Sec Borgs / Enables Peacekeeper Borgs

### DIFF
--- a/game_options.txt
+++ b/game_options.txt
@@ -157,11 +157,11 @@ ALLOW_AI_MULTICAM
 
 ## Secborg ###
 ## Uncomment to prevent the security cyborg model from being chosen
-#DISABLE_SECBORG
+DISABLE_SECBORG
 
 ## Peacekeeper Borg ###
 ## Uncomment to prevent the peacekeeper cyborg model from being chosen
-DISABLE_PEACEBORG
+#DISABLE_PEACEBORG
 
 ## AWAY MISSIONS ###
 


### PR DESCRIPTION
## Overview

Enables peacekeeper borgs and disables security borgs in anticipation of this rule change if **only** it passes successfully up through the admin team in the coming weeks.

**Silicons are not security**

![image](https://github.com/Bubberstation/config/assets/95130227/9f4d7bdc-382f-4a99-9c5e-742f0f6bdbc7)

## Why it's good for the game

Peacekeeper is fully capable of handling lower-level issues like minor fights between crew. Borgs do not need a full suite of security equipment (and a lethal laser gun) and it just incentivizes the player to play as security and hunt antags.

## What this PR isn't

This PR does not aim to move sprites or make exceptions for the ability to choose the security module (like in code red) if nukies are raiding the station.
