### PR TITLE
Disables Security Medic

### DIFF
--- a/jobconfig.toml
+++ b/jobconfig.toml
@@ -253,8 +253,8 @@
 [SECURITY_MEDIC]
 "Playtime Requirements" = 360
 "Required Account Age" = 7
-"Spawn Positions" = 1
-"Total Positions" = 1
+"Spawn Positions" = 0
+"Total Positions" = 0
 
 [SECURITY_OFFICER]
 "Playtime Requirements" = 300


### PR DESCRIPTION
**This PR is created in conjunction with this suggestion thread and should only be merged if it's accepted**
https://discordapp.com/channels/1059199070016655462/1071095123145924679/1133167867391651881

## Why this is good for the game

- Security medic is an extremely redundant job whose purpose can be easily filled with a medical doctor, borg, or paramedic.
- It locks the antag purely into security. It's too convenient. Pacification is two feet down the hall. It's extremely common to automatically check for any implants even if there's no suspicion for one.
- The only other way to combat security medic overreach is to slap an entire set of guidelines onto them to make them an over-glorified paramedics. Paramedics can do this job and are often standing around because every firefight is already treated by the security medic. (This is literally the funniest part of medical)
- Treating antags should take communication between both departments. You can already request a doctor to treat high threat antags in the brig since surgical processors are easy to come by. 