### PR TITLE
Removes Secborg

### DIFF
--- a/game_options.txt
+++ b/game_options.txt
@@ -157,11 +157,11 @@ ALLOW_AI_MULTICAM
 
 ## Secborg ###
 ## Uncomment to prevent the security cyborg model from being chosen
-#DISABLE_SECBORG
+DISABLE_SECBORG
 
 ## Peacekeeper Borg ###
 ## Uncomment to prevent the peacekeeper cyborg model from being chosen
-DISABLE_PEACEBORG
+#DISABLE_PEACEBORG
 
 ## AWAY MISSIONS ###
 


### PR DESCRIPTION
This PR was merged without prompt or discussion, that's why it was reverted. But I still firmly believe in secborg removal. 

## Why It's Good For The Game

Cyborgs are not security, period. We don't want them to act like security. If you give a borg comms, zip ties, baton, disabler, and a laser gun when emagged. Security borg is a security officer with All Access. They can do everything an officer can do. They will act like security and be baited to follow space law above their actual laws. Borgs should be keeping peace and the safety of the crew preserved, which Peacekeeper is perfect at doing without having the capabilities to go 1 on 1 with a contractor. Peacekeeper is actually **very** good at breaking up fights and stopping an armed head of staff from shooting into a crowd of unarmed medical doctors storming the bridge (and an actual example). They can roleplay promoting peace and negotiation above violence.

The solution to keeping secborg is to note, watchlist, and track every security borg player on an administrative level. We have 100+ people and this is not a solution. 