### PR TITLE
Hopefully fixes some issues with dynamic.

### DIFF
--- a/dynamic.json
+++ b/dynamic.json
@@ -6,10 +6,16 @@
 		"midround_upper_bound": 54000,
 		"midround_lower_bound": 6000,
 		"max_threat_level": 100,
-		"hijacked_random_event_injection_chance_modifier": 10,
+		"hijacked_random_event_injection_chance_modifier": 0,
 		"low_pop_player_threshold": 20,
 		"low_pop_maximum_threat": 10,
-		"latejoin_roll_chance": 50
+		"latejoin_roll_chance": 50,
+		"roundstart_split_curve_centre": 2,
+		"roundstart_split_curve_width": 1,
+		"threat_curve_centre": -3,
+		"threat_curve_width": 1,
+		"latejoin_delay_min": 3000,
+		"latejoin_delay_max": 6000	
 	},
 	"Roundstart": {
 		"Traitors": {


### PR DESCRIPTION
hijacked_random_event_injection_chance_modifier was set from 10 to 0 to prevent less heavy round injections.

"roundstart_split_curve_centre" was set from 1 (code) to 2 to encourage a bigger round start budget but a smaller midround budget.

"roundstart_split_curve_width" was set from 1.8 to 1 to encourage less variance in roundstart/midround budget.

"threat_curve_centre" was set from -2 (code) to -3 to make rounds less chaotic. According to in game, with a threat of 10, 43% of rounds are now more peaceful.

"threat_curve_width" was set from 1.8 to 1 to encourage less variance in threat levels.

"latejoin_delay_min" was set to 5 minutes, and "latejoin_delay_max" was set to 10 minutes. This means that latejoin roles will roll between 5 and 10 minutes.



This PR won't fix everything but it should be better than what is currently running.





