### PR TITLE
Makes xenos only spawn 1hr into a round, at a hugely increased cost.

### DIFF
--- a/dynamic.json
+++ b/dynamic.json
@@ -179,8 +179,9 @@
 
 		"Alien Infestation": {
 			"weight": 0,
+			"cost": 35,
 			"minimum_required_age": 7,
-			"minimum_round_time": 27000,
+			"minimum_round_time": 36000,
 			"requirements": [
 				101,
 				101,


### PR DESCRIPTION
Xenos now cost 35, up from 15.
This doesn't disable them outright, but makes them considerably more rare.
![image](https://github.com/Bubberstation/config/assets/53862927/9a9f6d77-b267-45e1-8949-3ebf031b327f)
