### PR TITLE
Disables Blood Cult from rolling

### DIFF
--- a/dynamic.json
+++ b/dynamic.json
@@ -44,7 +44,7 @@
 		"Blood Cult": {
 			"cost": 50,
 			"minimum_players": 30,
-			"weight": 1,
+			"weight": 0,
 			"minimum_required_age": 7,
 			"requirements": [
 				40,


### PR DESCRIPTION
It makes zero sense to me that we are still running a gamemode meant to be replaced by heretic. There are a plethora of reasons for not to have bloodcult enabled, and I will list some of them here.

## Sacrifices
Imagine for a moment that I was a traitor and I tried using a hypno flash on a security officer. Unfortunately it wouldn't work because they're mindshielded, so instead I result to throwing them in the supermatter. I would get bwoinked for this, of course. But I wouldn't get bwoinked for this as a cultist. Security offiers get sacrificed all the time for having a loyalty implant. You might say "Oh they get turned into a shard, they're still in the round!" and for what? To become a simplemob for approximately 5 minutes before being killed once and never being able to get revived again? Yeah, dogshit game design and a gamemode shouldn't exist that directly punishes security officers for simply existing.

## Objective to literally round remove someone
A core mechanic of blood cult is to round remove someone. Yeah. You're supposed to kill a specific someone and then sacrifice them. We did away with objectives such as these with traitor/heretic/ling objective reworks by only requiring someone to be killed once, or for them to not be able to escape alive. For some reason none of this is applied.

## Conversion gamemode
Conversion gamemodes are extremely bad for roleplay severs because bad faith players will use them to try and get converted at every turn just to become an antagonist. Nearly every cult round that has rolled, there is at least one regular player who intentionally goes out of their way to get converted.

## Monkey Mode
~~We should bring back the monkey infection gamemode.~~ Whenever there is a team based gamemode like cult, roleplay almost always gets thrown aside and everyone turns into gamer:tm: monkeys:tm: that bring OOC into IC and treat it like a competitive game. People who are ultra competitive shit bricks whenever something bad goes wrong, and people who do not know how to play cult feel entirely useless when they're converted and thrown into the fray.

## Dynamic Fucking Sucks:tm:
Dynamic is a very good system that has no problems at all. Dynamic rolling heretics, changeling, traitor, blob on a round that already has a cult threat is very good, very sane, and very human. A cultist with heretic/ling/traitor abilities is very balanced and very human.

## Why would I ready up
Cult only rolls during highpop because of the config setting and for some reason it typically does (See: Dynamic Fucking Sucks:tm:). Many players don't feel too fond of cult or nuke ops and prefer that these rounds don't happen. What ends up happening is that players don't ready up, resulting in a playercount 70 server only having 30 active crewmembers, resulting in dynamic being very underwhelming in picking antag types (See: Dynamic Fucking Sucks:tm:).

## Despite making up only 4% of the population, staff make up 80% of the cult.
It really sucks for admins to be basically forced to deadmin because all the admins were basically converted, resulting in an active staff count of 0 or 1.
