### PR TITLE
Disables Blob from rolling

### DIFF
--- a/dynamic.json
+++ b/dynamic.json
@@ -176,7 +176,7 @@
 		},
 
 		"Blob": {
-			"weight": 4,
+			"weight": 0,
 			"cost": 15,
 			"minimum_required_age": 7,
 			"minimum_players": 40,
@@ -195,7 +195,7 @@
 		},
 
 		"Blob Infection": {
-			"weight": 2,
+			"weight": 0,
 			"cost": 15,
 			"minimum_required_age": 7,
 			"minimum_players": 30,


### PR DESCRIPTION
# History Lesson

Blob was introduced early in /tg/ (Very early, like talking more than 10 years ago) as its own roundstart gamemode where someone would spawn in as blob and the crew would fight it. Rounds would last maybe between 15-30 minutes because if the blob wins, the round ends, and if the crew wins, the round also ends.

The gamemode was removed from rotation and instead converted into a very late round event (would occur after 45 minutes or so) as a means to make rounds ends sooner, much like Ninja with its "kill 2 heads" objectives. If the blob wins, the round ends, and if the crew wins, 90% of the time a shuttle call is made because the blob absorbed much of the station. This is because /tg/ was designed for 45 minute to 1 hour rounds as anything larger than that was too slow.

With several changes to how event spawn, as well as a standard bubberstation round being 2.5-3 hours, it makes absolutely zero sense to keep blob in rotation.

# Why remove and don't improve

https://github.com/Bubberstation/Bubberstation/pull/647

Extensive changes were made to blob in this PR and they were denied because there were no plans to accept PRs to nerf blob because they wanted to see how blob rounds went, which (again) makes absolutely no sense considering the problem isn't winrate but rather that blob is just annoying to fight and annoying to recover from, if that happens. There were also several issues with players always choosing meta spots and locations (Distributed Neurons always being a first pick) and then either going for a brute resist blob or a laser resist blob depending on engineering or security existing.

# Making a callout post on my twitter dot com

It's been 2 months since maintainers said there was a 1 month freeze on blob PRs/balancing because they wanted to wait and see how it turns out. That was a blatant lie considering there has been no statement or communication or literally anything about the state of blob since then.

