### PR TITLE
Removes excess job slots

### DIFF
--- a/jobconfig.toml
+++ b/jobconfig.toml
@@ -43,8 +43,8 @@
 [BARTENDER]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
-"Spawn Positions" = 2
-"Total Positions" = 2
+"Spawn Positions" = 1
+"Total Positions" = 1
 
 [BLUESHIELD]
 "Playtime Requirements" = 1200
@@ -61,8 +61,8 @@
 [BOUNCER]
 "Playtime Requirements" = 180
 "Required Account Age" = 0
-"Spawn Positions" = 2
-"Total Positions" = 2
+"Spawn Positions" = 1
+"Total Positions" = 1
 
 [CAPTAIN]
 "Playtime Requirements" = 1200
@@ -73,8 +73,8 @@
 [CARGO_TECHNICIAN]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
-"Spawn Positions" = 5
-"Total Positions" = 5
+"Spawn Positions" = 4
+"Total Positions" = 4
 
 [CHAPLAIN]
 "Playtime Requirements" = 0
@@ -115,8 +115,8 @@
 [CORRECTIONS_OFFICER]
 "Playtime Requirements" = 450
 "Required Account Age" = 7
-"Spawn Positions" = 2
-"Total Positions" = 2
+"Spawn Positions" = 1
+"Total Positions" = 1
 
 [CURATOR]
 "Playtime Requirements" = 0
@@ -127,14 +127,14 @@
 [CUSTOMS_AGENT]
 "Playtime Requirements" = 360
 "Required Account Age" = 0
-"Spawn Positions" = 2
-"Total Positions" = 2
+"Spawn Positions" = 1
+"Total Positions" = 1
 
 [CYBORG]
 "Playtime Requirements" = 120
 "Required Account Age" = 0
-"Spawn Positions" = 5
-"Total Positions" = 5
+"Spawn Positions" = 3
+"Total Positions" = 3
 
 [DETECTIVE]
 "Playtime Requirements" = 300
@@ -145,8 +145,8 @@
 [ENGINEERING_GUARD]
 "Playtime Requirements" = 180
 "Required Account Age" = 0
-"Spawn Positions" = 2
-"Total Positions" = 2
+"Spawn Positions" = 1
+"Total Positions" = 1
 
 [GENETICIST]
 "Playtime Requirements" = 0
@@ -175,14 +175,14 @@
 [LAWYER]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
-"Spawn Positions" = 2
-"Total Positions" = 2
+"Spawn Positions" = 1
+"Total Positions" = 1
 
 [MEDICAL_DOCTOR]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
-"Spawn Positions" = 5
-"Total Positions" = 5
+"Spawn Positions" = 4
+"Total Positions" = 4
 
 [MIME]
 "Playtime Requirements" = 0
@@ -199,8 +199,8 @@
 [ORDERLY]
 "Playtime Requirements" = 360
 "Required Account Age" = 0
-"Spawn Positions" = 2
-"Total Positions" = 2
+"Spawn Positions" = 1
+"Total Positions" = 1
 
 [PARAMEDIC]
 "Playtime Requirements" = 0
@@ -211,8 +211,8 @@
 [PRISONER]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
-"Spawn Positions" = 5
-"Total Positions" = 5
+"Spawn Positions" = 3
+"Total Positions" = 3
 
 [PSYCHOLOGIST]
 "Playtime Requirements" = 0
@@ -241,8 +241,8 @@
 [SCIENCE_GUARD]
 "Playtime Requirements" = 360
 "Required Account Age" = 0
-"Spawn Positions" = 2
-"Total Positions" = 2
+"Spawn Positions" = 1
+"Total Positions" = 1
 
 [SCIENTIST]
 "Playtime Requirements" = 0
@@ -271,8 +271,8 @@
 [STATION_ENGINEER]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
-"Spawn Positions" = 5
-"Total Positions" = 5
+"Spawn Positions" = 4
+"Total Positions" = 4
 
 [VANGUARD_OPERATIVE]
 "Playtime Requirements" = 400


### PR DESCRIPTION
There are some job slots we increased a bit too zealously in response to increased pop. This config change will put roles that should only have one person in them back to their original state, while also adjusting the max regular roles per department to 4.

Why it's good for the game:
There are many roles in SS13 that are very niche, and when you put 2 players into them, there's suddenly a great overlap where one person basically doesn't have a job. With clocking out and cryoing both as options now, we can safely reduce the slots.