### PR TITLE
Re-enables Dynamic

### DIFF
--- a/dynamic.json
+++ b/dynamic.json
@@ -1,7 +1,7 @@
 {
 	"Dynamic": {
-		"pop_per_requirement": 100,
-		"threat_per_midround_roll": 100,
+		"pop_per_requirement": 7,
+		"threat_per_midround_roll": 10,
 		"midround_roll_distance": 3000,
 		"midround_upper_bound": 72000,
 		"midround_lower_bound": 18000,


### PR DESCRIPTION
Dynamic was set to a pop-per-requirement of 100, with an equivalent threat-per-midround-roll of 100.

This means that basically no higher-level antags could spawn, and was likely caused by Dynamic being disabled for the Storyteller testmerge. I'm here to fix that.

Why is it good for the game? People come to Bubberstation for a mix of RP and action, not just contractors and traitors every shift. Bring this back until Storytellers are properly ready again.