### PR TITLE
2 more sec slots

### DIFF
--- a/jobconfig.toml
+++ b/jobconfig.toml
@@ -259,8 +259,8 @@
 [SECURITY_OFFICER]
 "Playtime Requirements" = 300
 "Required Account Age" = 0
-"Spawn Positions" = 4
-"Total Positions" = 4
+"Spawn Positions" = 6
+"Total Positions" = 6
 
 [SHAFT_MINER]
 "Playtime Requirements" = 0


### PR DESCRIPTION
After the most recent balance changes to Security, we need to restore Security to the same number of slots as before. With this said, we're going to try 6, and then move up to 8 if it's still in need of adjustment.