### PR TITLE
Command character age requirements

### DIFF
--- a/jobconfig.toml
+++ b/jobconfig.toml
@@ -49,7 +49,7 @@
 [BLUESHIELD]
 "Playtime Requirements" = 1200
 "Required Account Age" = 7
-"Required Character Age" = 24
+"Required Character Age" = 25
 "Spawn Positions" = 1
 "Total Positions" = 1
 
@@ -68,7 +68,7 @@
 [CAPTAIN]
 "Playtime Requirements" = 1200
 "Required Account Age" = 14
-"Required Character Age" = 30
+"Required Character Age" = 28
 "Spawn Positions" = 1
 "Total Positions" = 1
 
@@ -93,14 +93,14 @@
 [CHIEF_ENGINEER]
 "Playtime Requirements" = 1200
 "Required Account Age" = 7
-"Required Character Age" = 30
+"Required Character Age" = 28
 "Spawn Positions" = 1
 "Total Positions" = 1
 
 [CHIEF_MEDICAL_OFFICER]
 "Playtime Requirements" = 1200
 "Required Account Age" = 7
-"Required Character Age" = 30
+"Required Character Age" = 28
 "Spawn Positions" = 1
 "Total Positions" = 1
 
@@ -161,14 +161,14 @@
 [HEAD_OF_PERSONNEL]
 "Playtime Requirements" = 1200
 "Required Account Age" = 14
-"Required Character Age" = 24
+"Required Character Age" = 25
 "Spawn Positions" = 1
 "Total Positions" = 1
 
 [HEAD_OF_SECURITY]
 "Playtime Requirements" = 1800
 "Required Account Age" = 21
-"Required Character Age" = 30
+"Required Character Age" = 28
 "Spawn Positions" = 1
 "Total Positions" = 1
 
@@ -199,7 +199,7 @@
 [NANOTRASEN_CONSULTANT]
 "Playtime Requirements" = 1800
 "Required Account Age" = 21
-"Required Character Age" = 24
+"Required Character Age" = 25
 "Spawn Positions" = 1
 "Total Positions" = 1
 
@@ -236,7 +236,7 @@
 [RESEARCH_DIRECTOR]
 "Playtime Requirements" = 1200
 "Required Account Age" = 7
-"Required Character Age" = 30
+"Required Character Age" = 28
 "Spawn Positions" = 1
 "Total Positions" = 1
 

--- a/jobconfig.toml
+++ b/jobconfig.toml
@@ -49,6 +49,7 @@
 [BLUESHIELD]
 "Playtime Requirements" = 1200
 "Required Account Age" = 7
+"Required Character Age" = 24
 "Spawn Positions" = 1
 "Total Positions" = 1
 
@@ -67,6 +68,7 @@
 [CAPTAIN]
 "Playtime Requirements" = 1200
 "Required Account Age" = 14
+"Required Character Age" = 30
 "Spawn Positions" = 1
 "Total Positions" = 1
 
@@ -91,12 +93,14 @@
 [CHIEF_ENGINEER]
 "Playtime Requirements" = 1200
 "Required Account Age" = 7
+"Required Character Age" = 30
 "Spawn Positions" = 1
 "Total Positions" = 1
 
 [CHIEF_MEDICAL_OFFICER]
 "Playtime Requirements" = 1200
 "Required Account Age" = 7
+"Required Character Age" = 30
 "Spawn Positions" = 1
 "Total Positions" = 1
 
@@ -157,12 +161,14 @@
 [HEAD_OF_PERSONNEL]
 "Playtime Requirements" = 1200
 "Required Account Age" = 14
+"Required Character Age" = 24
 "Spawn Positions" = 1
 "Total Positions" = 1
 
 [HEAD_OF_SECURITY]
 "Playtime Requirements" = 1800
 "Required Account Age" = 21
+"Required Character Age" = 30
 "Spawn Positions" = 1
 "Total Positions" = 1
 
@@ -193,6 +199,7 @@
 [NANOTRASEN_CONSULTANT]
 "Playtime Requirements" = 1800
 "Required Account Age" = 21
+"Required Character Age" = 24
 "Spawn Positions" = 1
 "Total Positions" = 1
 
@@ -229,6 +236,7 @@
 [RESEARCH_DIRECTOR]
 "Playtime Requirements" = 1200
 "Required Account Age" = 7
+"Required Character Age" = 30
 "Spawn Positions" = 1
 "Total Positions" = 1
 


### PR DESCRIPTION
This makes it so most Command staff (except for the Blueshield, NTRep, and HoP, which need 24) need to be at least 30 years of age in-character before taking the role. 

Why this is good for the game:
This will make it seem, on a basic level, that characters are part of a world, and create the concept of an actual ladder to climb in-character.