### PR TITLE
Increases vote time to 2.5 minutes

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -221,7 +221,7 @@ MAX_ROCKING_VOTES 1
 VOTE_DELAY 6000
 
 ## time period (deciseconds) which voting session will last (default 1 minute)
-VOTE_PERIOD 1800
+VOTE_PERIOD 1500
 
 ## prevents dead players from voting or starting votes
 #NO_DEAD_VOTE

--- a/config.txt
+++ b/config.txt
@@ -221,7 +221,7 @@ MAX_ROCKING_VOTES 1
 VOTE_DELAY 6000
 
 ## time period (deciseconds) which voting session will last (default 1 minute)
-VOTE_PERIOD 600
+VOTE_PERIOD 1800
 
 ## prevents dead players from voting or starting votes
 #NO_DEAD_VOTE


### PR DESCRIPTION
This is gonna help ensure more DEMOCRACY happens as more people will remember to slip a vote in. This goes for EVERY vote. 

2.5 minute sis enough time to get the storyteller vote out before shiftstart and get the map vote out at the end even if the shuttle leaves early and is INTENDED TO GO WITH THIS PR https://github.com/Bubberstation/Bubberstation/pull/1214