### PR TITLE
Transfer vote is held at 2 hours 30 mininutes (instead of 2 hours 40 minutes). Continuing the vote only adds 30 minutes (instead of 1 hour).

### DIFF
--- a/skyrat/skyrat_config.txt
+++ b/skyrat/skyrat_config.txt
@@ -59,15 +59,15 @@ AUTOTRANSFER
 
 ## autovote initial delay (deciseconds in real time) before first automatic transfer vote call (default 120 minutes)
 ## Set to 0 to disable the subsystem altogether.
-VOTE_AUTOTRANSFER_INITIAL 96000
+VOTE_AUTOTRANSFER_INITIAL 90000
 
 ## autovote delay (deciseconds in real time) before sequential automatic transfer votes are called (default 30 minutes)
-VOTE_AUTOTRANSFER_INTERVAL 36000
+VOTE_AUTOTRANSFER_INTERVAL 18000
 
 ## autovote maximum votes until automatic transfer call. (default 4)
 ## Set to 0 to force automatic crew transfer after the 'vote_autotransfer_initial' elapsed.
 ## Set to -1 to disable the maximum votes cap.
-VOTE_AUTOTRANSFER_MAXIMUM 6
+VOTE_AUTOTRANSFER_MAXIMUM 2
 
 ## Policy for what people remember after dying and being brought back to life
 BLACKOUTPOLICY You remember nothing after you've blacked out and you do not remember who or what events killed you, however, you can have faint recollection of what led up to it.

--- a/skyrat/skyrat_config.txt
+++ b/skyrat/skyrat_config.txt
@@ -67,7 +67,7 @@ VOTE_AUTOTRANSFER_INTERVAL 18000
 ## autovote maximum votes until automatic transfer call. (default 4)
 ## Set to 0 to force automatic crew transfer after the 'vote_autotransfer_initial' elapsed.
 ## Set to -1 to disable the maximum votes cap.
-VOTE_AUTOTRANSFER_MAXIMUM 2
+VOTE_AUTOTRANSFER_MAXIMUM 4
 
 ## Policy for what people remember after dying and being brought back to life
 BLACKOUTPOLICY You remember nothing after you've blacked out and you do not remember who or what events killed you, however, you can have faint recollection of what led up to it.


### PR DESCRIPTION
1 hour is way too long for a vote that is usually extremely split. 30 minutes seems fine.



### Reasoning:

4 hour rounds are just way too long tbh. Part of the reason why I don't play command/important roles is that I am expecting the risk of the round being 4 hours due to continue, I know I can just cryo, but cryoing as a head is very awkward and can be bad for the server if you're cryoing in the middle of a station emergency/event.

Keeping vote extensions to 30 minutes will give crew more control over how long they want the round to be (Sometimes 30 minutes is all you need to wrap something up).





