### PR TITLE
Removes Blueshift because it doesn't work

### DIFF
--- a/maps.txt
+++ b/maps.txt
@@ -62,7 +62,6 @@ endmap
 
 map blueshift
 	minplayers 70
-	votable
 endmap
 
 map voidraptor


### PR DESCRIPTION
Blueshift has a massive bug where the powernet has be be basically redone by an engineering team due to the recent power update.

No one is going to fix blueshift because it's massive and it's an upstream map.

It's time for it to be disabled until it's fixed.