### PR TITLE
Increase paramedic slots

### DIFF
--- a/jobconfig.toml
+++ b/jobconfig.toml
@@ -205,8 +205,8 @@
 [PARAMEDIC]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
-"Spawn Positions" = 2
-"Total Positions" = 2
+"Spawn Positions" = 4
+"Total Positions" = 4
 
 [PRISONER]
 "Playtime Requirements" = 0


### PR DESCRIPTION
## About The Pull Request

Increases the paramedic slots to 4.

## Why It's Good For The Game

A single paramedic being traitor can lead to only a single paramed, which is insufficient particularly on high pop/chaotic rounds. It's a good roleplay job, and to learn the medical department.

## Changelog

:cl: LT3
balance: +2 paramedic slots
/:cl: