### PR TITLE
Increase janitor slots

### DIFF
--- a/jobconfig.toml
+++ b/jobconfig.toml
@@ -169,8 +169,8 @@
 [JANITOR]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
-"Spawn Positions" = 2
-"Total Positions" = 2
+"Spawn Positions" = 4
+"Total Positions" = 4
 
 [LAWYER]
 "Playtime Requirements" = 0


### PR DESCRIPTION
## About The Pull Request

Increases the janitor slots to 4.

## Why It's Good For The Game

It's a low impact service role, something to do and giving direction without going full assistant. Given the low expectations of the job, it doesn't hurt to have more.

## Changelog

:cl: LT3
balance: +2 janitor slots
/:cl: