### PR TITLE
Increase lavaland and space ruin budgets

### DIFF
--- a/game_options.txt
+++ b/game_options.txt
@@ -493,7 +493,7 @@ BOMBCAP 14
 ## a less lootfilled or smaller or less round effecting ruin costs less to
 ## spawn, while the converse is true. Alter this number to affect the amount
 ## of ruins.
-LAVALAND_BUDGET 80
+LAVALAND_BUDGET 60
 
 ## Ice Moon Budget
 ICEMOON_BUDGET 90

--- a/game_options.txt
+++ b/game_options.txt
@@ -493,7 +493,7 @@ BOMBCAP 14
 ## a less lootfilled or smaller or less round effecting ruin costs less to
 ## spawn, while the converse is true. Alter this number to affect the amount
 ## of ruins.
-LAVALAND_BUDGET 60
+LAVALAND_BUDGET 80
 
 ## Ice Moon Budget
 ICEMOON_BUDGET 90
@@ -502,7 +502,7 @@ ICEMOON_BUDGET 90
 OCEAN_BUDGET 60
 
 ## Space Ruin Budget
-Space_Budget 16
+Space_Budget 80
 
 ## Time in ds from when a player latejoins till the arrival shuttle docks at the station
 ## Must be at least 30. At least 55 recommended to be visually/aurally appropriate


### PR DESCRIPTION
Someone made the space ruin budget 16 on Skyrat and it wound up floating here. That means a couple asteroids and a small ruin or two will spawn and nothing else out in space. Bumping it to 80 allows for more stuff to spawn out in space and will give newbie mappers more incentive to make ruins for the server for people to explore.

--I also bumped up Lavaland's ruin budget to 80 for similar reasons.--
Lavaland is staying at 60, after consideration