### PR TITLE
Raises sec crew minimums

### DIFF
--- a/jobconfig.toml
+++ b/jobconfig.toml
@@ -113,7 +113,7 @@
 "Total Positions" = 2
 
 [CORRECTIONS_OFFICER]
-"Playtime Requirements" = 450
+"Playtime Requirements" = 600
 "Required Account Age" = 7
 "Spawn Positions" = 2
 "Total Positions" = 2
@@ -137,7 +137,7 @@
 "Total Positions" = 5
 
 [DETECTIVE]
-"Playtime Requirements" = 300
+"Playtime Requirements" = 600
 "Required Account Age" = 0
 "Spawn Positions" = 2
 "Total Positions" = 2
@@ -251,13 +251,13 @@
 "Total Positions" = 4
 
 [SECURITY_MEDIC]
-"Playtime Requirements" = 360
+"Playtime Requirements" = 600
 "Required Account Age" = 7
 "Spawn Positions" = 1
 "Total Positions" = 1
 
 [SECURITY_OFFICER]
-"Playtime Requirements" = 300
+"Playtime Requirements" = 600
 "Required Account Age" = 0
 "Spawn Positions" = 6
 "Total Positions" = 6
@@ -287,7 +287,7 @@
 "Total Positions" = 1
 
 [WARDEN]
-"Playtime Requirements" = 600
+"Playtime Requirements" = 1200
 "Required Account Age" = 7
 "Spawn Positions" = 1
 "Total Positions" = 1

--- a/jobconfig.toml
+++ b/jobconfig.toml
@@ -287,7 +287,7 @@
 "Total Positions" = 1
 
 [WARDEN]
-"Playtime Requirements" = 1200
+"Playtime Requirements" = 600
 "Required Account Age" = 7
 "Spawn Positions" = 1
 "Total Positions" = 1


### PR DESCRIPTION
About the PR
This raises the minimum amount of time players must play the server as  literally anyone else in order to play Security for the first time.
From 6 hours, to 10 hours.

This includes:
Security Medic,
Security Officer,
Detective,
Corrections Officer

Why it's good for the game:
This should ideally keep completely fresh players from joining Security as much as possible, and help boost the sec quality just a little bit.