### PR TITLE
Forces head roles to be playable by non-humans again

### DIFF
--- a/jobconfig.toml
+++ b/jobconfig.toml
@@ -1,10 +1,13 @@
 ## This is the configuration file for the job system.
 ## This will only be enabled when the config flag LOAD_JOBS_FROM_TXT is enabled.
 ## We use a system of keys here that directly correlate to the job, just to ensure they don't desync if we choose to change the name of a job.
-## You are able to change (as of now) four different variables in this file.
+## You are able to change (as of now) five (six if the job is a command head) different variables in this file.
 ## Total Positions are how many job slots you get in a shift, Spawn Positions are how many you get that load in at spawn. If you set this to -1, it is unrestricted.
 ## Playtime Requirements is in minutes, and the job will unlock when a player reaches that amount of time.
 ## However, that can be superseded by Required Account Age, which is a time in days that you need to have had an account on the server for.
+## Also there is a required character age in years. It prevents player from joining as this job, if their character's age as is lower than required. Setting it to 0 means it is turned off for this job.
+## Lastly there's Human Authority Whitelist Setting. You can set it to either "HUMANS_ONLY" or "NON_HUMANS_ALLOWED". Check the "Human Authority" setting on the game_options file to know which you should choose. Note that this entry only appears on jobs that are marked as heads of staff.
+
 ## As time goes on, more config options may be added to this file.
 ## You can use the admin verb 'Generate Job Configuration' in-game to auto-regenerate this config as a downloadable file without having to manually edit this file if we add more jobs or more things you can edit here.
 ## It will always respect prior-existing values in the config, but will appropriately add more fields when they generate.
@@ -19,287 +22,342 @@
 [AI]
 "Playtime Requirements" = 2400
 "Required Account Age" = 30
+"# Required Character Age" = 0
 "Spawn Positions" = 1
 "Total Positions" = 1
 
 [ASSISTANT]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 100
 "Total Positions" = 100
 
 [ATMOSPHERIC_TECHNICIAN]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 3
 "Total Positions" = 3
 
 [BARBER]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 1
 "Total Positions" = 1
 
 [BARTENDER]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 2
 "Total Positions" = 2
 
 [BLUESHIELD]
 "Playtime Requirements" = 3600
 "Required Account Age" = 7
+"# Required Character Age" = 0
 "Spawn Positions" = 1
 "Total Positions" = 1
 
 [BOTANIST]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 2
 "Total Positions" = 2
 
 [BOUNCER]
 "Playtime Requirements" = 180
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 2
 "Total Positions" = 2
 
 [CAPTAIN]
+"Human Authority Whitelist Setting" = "NON_HUMANS_ALLOWED"
 "Playtime Requirements" = 2400
 "Required Account Age" = 14
+"# Required Character Age" = 0
 "Spawn Positions" = 1
 "Total Positions" = 1
 
 [CARGO_TECHNICIAN]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 5
 "Total Positions" = 5
 
 [CHAPLAIN]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 1
 "Total Positions" = 1
 
 [CHEMIST]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 2
 "Total Positions" = 2
 
 [CHIEF_ENGINEER]
+"Human Authority Whitelist Setting" = "NON_HUMANS_ALLOWED"
 "Playtime Requirements" = 2400
 "Required Account Age" = 7
+"# Required Character Age" = 0
 "Spawn Positions" = 1
 "Total Positions" = 1
 
 [CHIEF_MEDICAL_OFFICER]
+"Human Authority Whitelist Setting" = "NON_HUMANS_ALLOWED"
 "Playtime Requirements" = 2400
 "Required Account Age" = 7
+"# Required Character Age" = 0
 "Spawn Positions" = 1
 "Total Positions" = 1
 
 [CLOWN]
 "Playtime Requirements" = 0
 "Required Account Age" = 7
+"# Required Character Age" = 0
 "Spawn Positions" = 1
 "Total Positions" = 1
 
 [COOK]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 2
 "Total Positions" = 2
 
 [CORRECTIONS_OFFICER]
 "Playtime Requirements" = 600
 "Required Account Age" = 7
+"# Required Character Age" = 0
 "Spawn Positions" = 2
 "Total Positions" = 2
 
 [CURATOR]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 1
 "Total Positions" = 1
 
 [CUSTOMS_AGENT]
 "Playtime Requirements" = 360
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 2
 "Total Positions" = 2
 
 [CYBORG]
 "Playtime Requirements" = 120
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 5
 "Total Positions" = 5
 
 [DETECTIVE]
 "Playtime Requirements" = 600
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 2
 "Total Positions" = 2
 
 [ENGINEERING_GUARD]
 "Playtime Requirements" = 180
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 2
 "Total Positions" = 2
 
 [GENETICIST]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 2
 "Total Positions" = 2
 
 [HEAD_OF_PERSONNEL]
+"Human Authority Whitelist Setting" = "NON_HUMANS_ALLOWED"
 "Playtime Requirements" = 2400
 "Required Account Age" = 14
+"# Required Character Age" = 0
 "Spawn Positions" = 1
 "Total Positions" = 1
 
 [HEAD_OF_SECURITY]
+"Human Authority Whitelist Setting" = "NON_HUMANS_ALLOWED"
 "Playtime Requirements" = 3600
 "Required Account Age" = 21
+"# Required Character Age" = 0
 "Spawn Positions" = 1
 "Total Positions" = 1
 
 [JANITOR]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 4
 "Total Positions" = 4
 
 [LAWYER]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 2
 "Total Positions" = 2
 
 [MEDICAL_DOCTOR]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 5
 "Total Positions" = 5
 
 [MIME]
 "Playtime Requirements" = 0
 "Required Account Age" = 7
+"# Required Character Age" = 0
 "Spawn Positions" = 1
 "Total Positions" = 1
 
 [NANOTRASEN_CONSULTANT]
 "Playtime Requirements" = 2400
 "Required Account Age" = 21
+"# Required Character Age" = 0
 "Spawn Positions" = 1
 "Total Positions" = 1
 
 [ORDERLY]
 "Playtime Requirements" = 360
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 2
 "Total Positions" = 2
 
 [PARAMEDIC]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 4
 "Total Positions" = 4
 
 [PRISONER]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 5
 "Total Positions" = 5
 
 [PSYCHOLOGIST]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 1
 "Total Positions" = 1
 
 [QUARTERMASTER]
+"Human Authority Whitelist Setting" = "NON_HUMANS_ALLOWED"
 "Playtime Requirements" = 2400
 "Required Account Age" = 7
+"# Required Character Age" = 0
 "Spawn Positions" = 1
 "Total Positions" = 1
 
 [RESEARCH_DIRECTOR]
+"Human Authority Whitelist Setting" = "NON_HUMANS_ALLOWED"
 "Playtime Requirements" = 2400
 "Required Account Age" = 7
+"# Required Character Age" = 0
 "Spawn Positions" = 1
 "Total Positions" = 1
 
 [ROBOTICIST]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 2
 "Total Positions" = 2
 
 [SCIENCE_GUARD]
 "Playtime Requirements" = 360
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 2
 "Total Positions" = 2
 
 [SCIENTIST]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 4
 "Total Positions" = 4
 
 [SECURITY_MEDIC]
 "Playtime Requirements" = 600
 "Required Account Age" = 7
+"# Required Character Age" = 0
 "Spawn Positions" = 1
 "Total Positions" = 1
 
 [SECURITY_OFFICER]
 "Playtime Requirements" = 600
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 6
 "Total Positions" = 6
 
 [SHAFT_MINER]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 3
 "Total Positions" = 3
 
 [STATION_ENGINEER]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 5
 "Total Positions" = 5
 
 [VANGUARD_OPERATIVE]
 "Playtime Requirements" = 400
 "Required Account Age" = 40
+"# Required Character Age" = 0
 "Spawn Positions" = 0
 "Total Positions" = 0
 
 [VIROLOGIST]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 1
 "Total Positions" = 1
 
 [WARDEN]
 "Playtime Requirements" = 600
 "Required Account Age" = 7
+"# Required Character Age" = 0
 "Spawn Positions" = 1
 "Total Positions" = 1
 
 [BLACKSMITH]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 1
 "Total Positions" = 1
 
 [CORONER]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
+"# Required Character Age" = 0
 "Spawn Positions" = 1
 "Total Positions" = 1


### PR DESCRIPTION
Due to an upstream pull from TG, jobs configs were changed to use a different system for whether or not heads can be human or not.

This uses the new system to let them be non-humans, as per usual.

Also updates the file with another var that was added at some point (for minimum age), but all entries are commented out.