### PR TITLE
Reduced the initial transfer vote to 2h25m

### DIFF
--- a/skyrat/skyrat_config.txt
+++ b/skyrat/skyrat_config.txt
@@ -61,7 +61,7 @@ AUTOTRANSFER
 
 ## autovote initial delay (deciseconds in real time) before first automatic transfer vote call (default 120 minutes)
 ## Set to 0 to disable the subsystem altogether.
-VOTE_AUTOTRANSFER_INITIAL 96000
+VOTE_AUTOTRANSFER_INITIAL 87000
 
 ## autovote delay (deciseconds in real time) before sequential automatic transfer votes are called (default 30 minutes)
 VOTE_AUTOTRANSFER_INTERVAL 18000


### PR DESCRIPTION
That's it, I trimmed 20 minutes from the first transfer vote following a public vote on the discord. Many people, me included, wish for (slightly) shorter round times, and this reduces the total minimum round time from 2:50/3:00 to 2:30/2:45.